### PR TITLE
Add BulkPublish

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - **[LinkedIn Articles](https://www.linkedin.com/)** - A professional platform for distributing thought leadership content.
 - **[Buffer](https://buffer.com/)** - A tool for scheduling and sharing content on social media.
 - **[Hootsuite](https://hootsuite.com/)** - A social media management tool for distributing and tracking content.
+- **[BulkPublish](https://www.bulkpublish.com/)** - A social media publishing API for distributing content across 11 platforms with REST API, Python & Node.js SDKs.
 
 ## SEO and Content Optimization
 


### PR DESCRIPTION
Add [BulkPublish](https://www.bulkpublish.com) to the Content Distribution Platforms section.

BulkPublish is a social media publishing API for distributing content across 11 platforms (Facebook, Instagram, X/Twitter, TikTok, YouTube, Threads, Bluesky, Pinterest, Google Business, LinkedIn, Mastodon). It offers a REST API with Python & Node.js SDKs, and integrations with Zapier, n8n, and Make.

- Website: https://www.bulkpublish.com
- GitHub: https://github.com/azeemkafridi/bulkpublish-api
- License: MIT
- Free tier available